### PR TITLE
Fix use of pandoc --smart option

### DIFF
--- a/tools/md-to-html
+++ b/tools/md-to-html
@@ -18,5 +18,5 @@ mydir=$(dirname "$0")
 
 $mydir/highlighter < $1 |
   $mydir/macros |
-  pandoc -f markdown_github-hard_line_breaks --smart \
+  pandoc -f markdown_github-hard_line_breaks+smart \
     --data-dir=$mydir/pandoc-data -o $2 $opts


### PR DESCRIPTION
As of pandoc 2.2 (but maybe before, I just noticed it now and this is the version I have), `make` fails with:

    ./tools/md-to-html src/learn/cookbook.md src/learn/cookbook.html
    --smart/-S has been removed.  Use +smart or -smart extension instead.
    For example: pandoc -f markdown+smart -t markdown-smart.
    Try pandoc --help for more information.

This change makes the error go away, but I am not completely sure if the conversion is unaffected.